### PR TITLE
Allow Postmark API exceptions to be thrown

### DIFF
--- a/src/Postmark/ThrowExceptionOnFailurePlugin.php
+++ b/src/Postmark/ThrowExceptionOnFailurePlugin.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Postmark;
+
+class ThrowExceptionOnFailurePlugin implements \Swift_Events_ResponseListener
+{
+    public function responseReceived(\Swift_Events_ResponseEvent $event)
+    {
+        if (!$event->isValid()) {
+            throw new \Swift_TransportException($event->getResponse());
+        }
+    }
+}


### PR DESCRIPTION
Integrated changes from https://github.com/wildbit/swiftmailer-postmark/commit/91afdf3fdb0a554f535efb1045461a924b88c63c

To enable, add the following to config.yml:
````
SilverStripe\Control\Email\SwiftMailer:
  swift_plugins:
    - Postmark\ThrowExceptionOnFailurePlugin
````

This means if the send failed due to the Postmark API not returning a success response, it will error, rather than pretending the email had sent sucessfully.